### PR TITLE
chore: add php api alarm to slack forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+**/packaged.yml

--- a/php-api-alarm-to-slack/README.md
+++ b/php-api-alarm-to-slack/README.md
@@ -1,0 +1,44 @@
+# cloudwatch-alarm-to-slack
+[Amazon CloudWatch](https://aws.amazon.com/cloudwatch/) alarm notifications to
+[Slack](https://slack.com/) streaming function for
+[AWS Lambda](https://aws.amazon.com/lambda/).
+
+## Setup
+
+### Function configuration
+Add the function code to AWS Lambda with the following configuration options:  
+
+Key     | Value
+--------|--------------
+Runtime | Node.js 6.10
+Handler | index.handler
+Role    | AWSLambdaBasicExecutionRole
+Memory  | 128 (MB)
+Timeout | 3 sec
+KMS key | aws/lambda
+
+### Environment variables
+Set the following required environment variable for the Lambda function:
+
+Key     | Value
+--------|--------------
+webhook | [AWS KMS](https://aws.amazon.com/kms/) encrypted Slack WebHook URL.
+
+Set the following optional environment variables for the Lambda function:
+
+Key        | Value
+-----------|--------------
+channel    | Slack channel to send the notifications to.
+username   | Bot username used for the slack messages.
+icon_emoji | Bot icon emoji used for the slack messages.
+icon_url   | Bot icon url used for the slack messages.
+
+### Trigger configuration
+Add the desired [Amazon SNS](https://aws.amazon.com/sns/) topic as trigger for
+the Lambda function.
+
+## License
+Released under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Author
+[Sebastian Tschan](https://blueimp.net/)

--- a/php-api-alarm-to-slack/deploy.sh
+++ b/php-api-alarm-to-slack/deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+aws-vault exec allthings-admin -- aws cloudformation package \
+  --template-file template.yml \
+  --s3-bucket allthings-lambda-deployments-eu-west-1 \
+  --output-template-file packaged.yml
+
+aws-vault exec allthings-admin -- aws cloudformation deploy \
+  --template-file ./packaged.yml \
+  --stack-name php-api-alarm-to-slack \
+  --capabilities CAPABILITY_IAM

--- a/php-api-alarm-to-slack/index.js
+++ b/php-api-alarm-to-slack/index.js
@@ -77,7 +77,7 @@ function buildSlackMessage (data) {
     ~editorString
     ~'fields*20*40timestamp*2c*20*40message*2c*20request_uri*2c*20status*0a*7c*20sort*20*40timestamp*20desc
     ~isLiveTail~false
-    ~source~(~'*2faws*2felasticbeanstalk*2f${data.AlarmDescription}*2fdocker*2fnginx))`.replace(/\r?\n|\r/g, '')
+    ~source~(~'*2faws*2felasticbeanstalk*2f${data.AlarmDescription}*2fdocker*2fnginx))`.replace(/\r?\n|\r|\s/g, '')
 
   const logLink = `<${linkTarget}|View Logs>`
   return {

--- a/php-api-alarm-to-slack/index.js
+++ b/php-api-alarm-to-slack/index.js
@@ -1,0 +1,127 @@
+/*
+ * CloudWatch alarm notifications to Slack streaming function for AWS Lambda.
+ * https://github.com/blueimp/aws-lambda
+ *
+ * Required environment variables:
+ * - webhook:     AWS KMS encrypted Slack WebHook URL.
+ *
+ * Optional environment variables:
+ * - channel:     Slack channel to send the messages to.
+ * - username:    Bot username used for the slack messages.
+ * - icon_emoji:  Bot icon emoji used for the slack messages.
+ * - icon_url:    Bot icon url used for the slack messages.
+ *
+ * Copyright 2017, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Licensed under the MIT license:
+ * https://opensource.org/licenses/MIT
+ */
+
+'use strict'
+
+const ENV = process.env
+if (!ENV.webhook) throw new Error('Missing environment variable: webhook')
+
+let webhook
+
+const AWS = require('aws-sdk')
+const url = require('url')
+const https = require('https')
+
+function handleResponse (response, callback) {
+  const statusCode = response.statusCode
+  console.log('Status code:', statusCode)
+  let responseBody = ''
+  response
+    .on('data', chunk => {
+      responseBody += chunk
+    })
+    .on('end', chunk => {
+      console.log('Response:', responseBody)
+      if (statusCode >= 200 && statusCode < 300) {
+        callback(null, 'Request completed successfully.')
+      } else {
+        callback(new Error(`Request failed with status code ${statusCode}.`))
+      }
+    })
+}
+
+function post (requestURL, data, callback) {
+  const body = JSON.stringify(data)
+  const options = url.parse(requestURL)
+  options.method = 'POST'
+  options.headers = {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body)
+  }
+  console.log('Request options:', JSON.stringify(options))
+  console.log('Request body:', body)
+  https
+    .request(options, response => {
+      handleResponse(response, callback)
+    })
+    .on('error', err => {
+      callback(err)
+    })
+    .end(body)
+}
+
+function buildSlackMessage (data) {
+  const linkTarget = `https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1
+    #logs-insights:queryDetail=
+    ~(end~0
+    ~start~-3600
+    ~timeType~'RELATIVE
+    ~unit~'seconds
+    ~editorString
+    ~'fields*20*40timestamp*2c*20*40message*2c*20request_uri*2c*20status*0a*7c*20sort*20*40timestamp*20desc
+    ~isLiveTail~false
+    ~source~(~'*2faws*2felasticbeanstalk*2f${data.Description}*2fdocker*2fnginx))`.replace(/\r?\n|\r/g, '')
+
+  const logLink = `<${linkTarget}|View Logs>`
+  return {
+    channel: ENV.channel,
+    username: ENV.username,
+    icon_emoji: ENV.icon_emoji,
+    icon_url: ENV.icon_url,
+    attachments: [
+      {
+        fallback: data.AlarmName,
+        title: "Internal Server Errors",
+        text: `Encountered request(s) with status code 500 in the last ${data.Trigger.Period} seconds.\n${logLink}`,
+        color: 'danger'
+      }
+    ]
+  }
+}
+
+function parseSNSMessage (message) {
+  console.log('SNS Message:', message)
+  return JSON.parse(message)
+}
+
+function processEvent (event, context, callback) {
+  console.log('Event:', JSON.stringify(event))
+  const snsMessage = parseSNSMessage(event.Records[0].Sns.Message)
+  const postData = buildSlackMessage(snsMessage)
+  post(webhook, postData, callback)
+}
+
+function decryptAndProcess (event, context, callback) {
+  const kms = new AWS.KMS()
+  const enc = { CiphertextBlob: Buffer.from(ENV.webhook, 'base64') }
+  kms.decrypt(enc, (err, data) => {
+    if (err) return callback(err)
+    webhook = data.Plaintext.toString('ascii')
+    processEvent(event, context, callback)
+  })
+}
+
+exports.handler = (event, context, callback) => {
+  if (webhook) {
+    processEvent(event, context, callback)
+  } else {
+    decryptAndProcess(event, context, callback)
+  }
+}

--- a/php-api-alarm-to-slack/index.js
+++ b/php-api-alarm-to-slack/index.js
@@ -77,7 +77,7 @@ function buildSlackMessage (data) {
     ~editorString
     ~'fields*20*40timestamp*2c*20*40message*2c*20request_uri*2c*20status*0a*7c*20sort*20*40timestamp*20desc
     ~isLiveTail~false
-    ~source~(~'*2faws*2felasticbeanstalk*2f${data.Description}*2fdocker*2fnginx))`.replace(/\r?\n|\r/g, '')
+    ~source~(~'*2faws*2felasticbeanstalk*2f${data.AlarmDescription}*2fdocker*2fnginx))`.replace(/\r?\n|\r/g, '')
 
   const logLink = `<${linkTarget}|View Logs>`
   return {

--- a/php-api-alarm-to-slack/template.yml
+++ b/php-api-alarm-to-slack/template.yml
@@ -1,0 +1,102 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+
+Description: Handler that subscribes to SNS topic with internal server errors from the AWSTemplateFormatVersion
+
+Parameters:
+
+  ApiLogGroupName:
+    Type: String
+    Description: Name of the log group to filter for errors
+    Default: /aws/elasticbeanstalk/api-production/docker/nginx
+
+  WorkerApiLogGroupName:
+    Type: String
+    Description: Name of the log group to filter for errors
+    Default: /aws/elasticbeanstalk/api-worker-production/docker/nginx
+
+  Api500StatusMetricName:
+    Type: String
+    Description: Name of 500 status metric for the api
+    Default: api-500-status-production
+
+  WorkerApi500StatusMetricName:
+    Type: String
+    Description: Name of 500 status metric for the worker api
+    Default: worker-api-500-status-production
+
+
+Resources:
+
+  Api500ErrorsToSlackHandler:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs12.x
+      Role: arn:aws:iam::799212276699:role/aws-lambda-basic-execution-role
+      CodeUri: .
+      MemorySize: 128
+      Timeout: 5
+      Environment:
+        Variables:
+          webhook: AQECAHj6Y8swFFZ8sg2A5LDqzMqXTngYQ4IY+YtXTBbxtG0Z0wAAAK8wgawGCSqGSIb3DQEHBqCBnjCBmwIBADCBlQYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAyscuWhAv/SJ3u/ry0CARCAaFZGSzR4TS4uvgtfBHQjCYKZc4/skKA9CWqOVijEuftWp0GxjRdaKCqqF09OIrOiOzRkggiDCvWn7TxMr+lWjbY3O1W96nu2VzpCA7/VHJE9Cddod0g2qfgI9Au4OPchi47xKmsd19dy
+      Events:
+        SNSEvent:
+          Type: SNS
+          Properties:
+            Topic: !Ref CloudWatchAlarmsTopic
+
+  Api500Errors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: 
+        - !Ref CloudWatchAlarmsTopic
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: api-production # used in handler by convention as the log group name
+      EvaluationPeriods: 1
+      MetricName: !Ref Api500StatusMetricName
+      Namespace: php-api
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  WorkerApi500Errors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: 
+        - !Ref CloudWatchAlarmsTopic
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: api-worker-production # used in handler by convention as the log group name
+      EvaluationPeriods: 1
+      MetricName: !Ref WorkerApi500StatusMetricName
+      Namespace: php-api
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  Api500ErrorsFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ApiLogGroupName
+      FilterPattern: "{$.status = 5*}"
+      MetricTransformations:
+        -
+          MetricNamespace: php-api
+          MetricName: !Ref Api500StatusMetricName
+          MetricValue: 1
+
+  WorkerApi500ErrorsFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref WorkerApiLogGroupName
+      FilterPattern: "{$.status = 5*}"
+      MetricTransformations:
+        -
+          MetricNamespace: php-api
+          MetricName: !Ref WorkerApi500StatusMetricName
+          MetricValue: 1
+
+  CloudWatchAlarmsTopic:
+    Type: AWS::SNS::Topic

--- a/php-api-alarm-to-slack/test-event.json
+++ b/php-api-alarm-to-slack/test-event.json
@@ -1,0 +1,22 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:eu-west-1:000000000000:cloudwatch-alarms:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "TopicArn": "arn:aws:sns:eu-west-1:000000000000:cloudwatch-alarms",
+        "Subject": "ALARM: \"Example alarm name\" in EU - Ireland",
+        "Message": "{\"AlarmName\":\"Example alarm name\",\"AlarmDescription\":\"Example alarm description.\",\"AWSAccountId\":\"000000000000\",\"NewStateValue\":\"ALARM\",\"NewStateReason\":\"Threshold Crossed: 1 datapoint (10.0) was greater than or equal to the threshold (1.0).\",\"StateChangeTime\":\"2017-01-12T16:30:42.236+0000\",\"Region\":\"EU - Ireland\",\"OldStateValue\":\"OK\",\"Trigger\":{\"MetricName\":\"DeliveryErrors\",\"Namespace\":\"ExampleNamespace\",\"Statistic\":\"SUM\",\"Unit\":null,\"Dimensions\":[],\"Period\":300,\"EvaluationPeriods\":1,\"ComparisonOperator\":\"GreaterThanOrEqualToThreshold\",\"Threshold\":1.0}}",
+        "Timestamp": "2017-01-12T16:30:42.318Z",
+        "SignatureVersion": "1",
+        "Signature": "Cg==",
+        "SigningCertUrl": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.pem",
+        "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:000000000000:cloudwatch-alarms:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "MessageAttributes": {}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR implements adding the php api errors to slack forwarding.
I used aws SAM because I didn't really wanted to add the whole serverless overhead..
All those slack forwarding could possibly be optimized and maybe consolidated, but I'd like to keep the scope down to "get the php api errors pushed to slack again".
